### PR TITLE
#STRW-58 stock generator column name 변경

### DIFF
--- a/data/stock_generator.py
+++ b/data/stock_generator.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from random import sample, randint
 from data_constant import KOSPI_200, TICKER_NAME, DATA_PATH, START_DATE, END_DATE
 
+
 def get_random_date(train_days: int, init_days: int) -> "pd.Timestamp":
     """
     return random date between START_DATE and END_DATE
@@ -45,7 +46,7 @@ def get_data_by_datetime_in_one_row(
             : train_days + init_days
         ]
         # 3. 찾았다면, 해당 정보를 배열에 append
-        ticker_list.append(company['Symbol'])
+        ticker_list.append(company["Symbol"])
         res.append(company_dataframe.reset_index(drop=True))
 
     # 4. KOSPI INDEX 정보 추가 - '종가'를 기준으로 함
@@ -74,7 +75,7 @@ def get_data_by_datetime_in_one_row(
             str(ticker_list[i]) + "_high",
             str(ticker_list[i]) + "_low",
             str(ticker_list[i]) + "_close",
-            str(ticker_list[i]) + "_volume"
+            str(ticker_list[i]) + "_volume",
         ]
     df_label += ["kospi", "exchange_rate"]
     result.columns = df_label

--- a/data/stock_generator.py
+++ b/data/stock_generator.py
@@ -4,7 +4,6 @@ from datetime import date, timedelta
 from random import sample, randint
 from data_constant import KOSPI_200, TICKER_NAME, DATA_PATH, START_DATE, END_DATE
 
-
 def get_random_date(train_days: int, init_days: int) -> "pd.Timestamp":
     """
     return random date between START_DATE and END_DATE
@@ -24,6 +23,7 @@ def get_data_by_datetime_in_one_row(
     A function that returns DataFrame with `quantity` stocks with `train_days` + `init_days` with exchange_rate and kospi_index
     """
     # 0. initialize list to store individual df for merge
+    ticker_list = []
     res = []
 
     # 1. 날짜 랜덤 추출 (train_duration, init_duration 반영)
@@ -45,6 +45,7 @@ def get_data_by_datetime_in_one_row(
             : train_days + init_days
         ]
         # 3. 찾았다면, 해당 정보를 배열에 append
+        ticker_list.append(company['Symbol'])
         res.append(company_dataframe.reset_index(drop=True))
 
     # 4. KOSPI INDEX 정보 추가 - '종가'를 기준으로 함
@@ -66,14 +67,14 @@ def get_data_by_datetime_in_one_row(
     # 6. Merge Dataframe, reset labelname, and return final DataFrame
     result = pd.concat(res, axis=1)
     df_label = []
-    for i in range(1, quantity + 1):
+    for i in range(0, quantity):
         df_label += [
             "date",
-            "open" + str(i),
-            "high" + str(i),
-            "low" + str(i),
-            "close" + str(i),
-            "volume" + str(i),
+            str(ticker_list[i]) + "_open",
+            str(ticker_list[i]) + "_high",
+            str(ticker_list[i]) + "_low",
+            str(ticker_list[i]) + "_close",
+            str(ticker_list[i]) + "_volume"
         ]
     df_label += ["kospi", "exchange_rate"]
     result.columns = df_label


### PR DESCRIPTION
# 기능 Issue
<!-- Bug Fix / Feature Develop -->
Linked Feature backlog : #STRW-58

## PR 목적

- 본 PR에서는 `stock_generator.py`의 함수 리턴값의 Column name의 변경을 구현합니다.
   
## 작업 설명

- `ticker_list` 변수를 추가하고, 반환할 주가데이터에 해당하는 `ticker`를 따로 저장해둡니다.
- DataFrame의 col rename하는 과정에서 이를 반영합니다.

## 수행 이미지 (optional)

`TO-BE` result of DataFrame

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/32982728/140635305-b24ce4e2-534c-47ce-9062-0560a4b56510.png">

## 라벨링 확인
작업 우선순위 : 중
